### PR TITLE
include required <sys/sysmacros.h>

### DIFF
--- a/sltar.c
+++ b/sltar.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/param.h>
+#include <sys/sysmacros.h>
 #include <ftw.h>
 #include <grp.h>
 #include <pwd.h>


### PR DESCRIPTION
according to makedev(3), <sys/sysmacros.h> is required for major, minor, and makedev,
and without this header it would not compile on my machine.